### PR TITLE
Added SSH flag support

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/Tailscale-1-Settings.page
+++ b/src/usr/local/emhttp/plugins/tailscale/Tailscale-1-Settings.page
@@ -84,6 +84,17 @@ Accept DNS
 > Accept DNS from the tailnet.
 > If set to "Ignore", the plugin will not modify the setting.
 
+Enable SSH
+: <select name='SSH' size='1'>
+    <?= mk_option($tailscale_config['SSH'], '0', "No");?>
+    <?= mk_option($tailscale_config['SSH'], '1', "Yes");?>
+    <?= mk_option($tailscale_config['SSH'], '2', "Ignore");?>
+</select>
+
+> Enable SSH access in Tailscale Admin Console
+> If set to "Ignore", the plugin will not modify the setting.
+
+
 ### Save Settings
 
 **Tailscale will be restarted when changes are applied.**

--- a/src/usr/local/emhttp/plugins/tailscale/include/tailscale-watcher/apply-settings.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/tailscale-watcher/apply-settings.php
@@ -21,3 +21,14 @@ switch ($tailscale_config['ACCEPT_DNS']) {
     default:
         logmsg("Ignoring accept-dns");
 }
+
+switch ($tailscale_config['SSH']) {
+    case "0":
+        run_command("/usr/local/sbin/tailscale set --ssh=false");
+        break;
+    case "1":
+        run_command("/usr/local/sbin/tailscale set --ssh=true");
+        break;
+    default:
+        logmsg("Ignoring ssh");
+}

--- a/src/usr/local/emhttp/plugins/tailscale/settings.json
+++ b/src/usr/local/emhttp/plugins/tailscale/settings.json
@@ -15,6 +15,10 @@
 		"default": "0",
 		"description": "Use routes from the tailnet"
 	},
+	"SSH": {
+		"default": "0",
+		"description": "Enable SSH in Tailscale Admin Console"
+	},
     "SYSCTL_IP_FORWARD": {
 		"default": "0",
 		"description": "Enable IP forwarding in sysctl"


### PR DESCRIPTION
Hello,

This is my first time trying to add anything to an unraid plugin, please forgive me if I’ve missed something important. I added what I think should provide an option for the —ssh flag. I made some similar edits to my live local plugin and they worked but the plugin structure looks a bit different (maybe I have an older version?), so I hope this works.